### PR TITLE
Autoclear based on job health

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/victorops/ActiveNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/victorops/ActiveNotifier.java
@@ -67,7 +67,6 @@ public class ActiveNotifier implements FineGrainedNotifier {
 
     static String getBuildIncident(AbstractBuild r) {
         AbstractProject<?, ?> project = r.getProject();
-        return "Jenkins " + project.getLastBuild().toString();
+        return "Jenkins: " + project.getDisplayName().toString();
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/victorops/ActiveNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/victorops/ActiveNotifier.java
@@ -52,11 +52,11 @@ public class ActiveNotifier implements FineGrainedNotifier {
     static String getBuildStatus(AbstractBuild r) {
         Result result = r.getResult();
         if (result == Result.SUCCESS) {
-            return "INFO";
+            return "RECOVERY";
         } else if (result == Result.FAILURE) {
             return "CRITICAL";
         } else {
-            return "WARNING";
+            return "INFO";
         }
     }
 


### PR DESCRIPTION
Currently, any individual build will be it's own event in Victorops. This change uses the job name instead of the build name, so that if a job returns to healthy, it will auto-clear the alert in victorops.